### PR TITLE
fix typo

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,7 +29,7 @@
 - [ECMAScriptの実装ってどれぐらいあるの?](slide/29.md)
 - [ECMAScriptの実装状況ってどうなの?](slide/30.md)
 - [Transpilerって何?](slide/31.md)
-	- [Tranpiler is not Learning tools](slide/32.md)
+	- [Transpiler is not Learning tools](slide/32.md)
 - [Polyfillって何?](slide/33.md)
 - [ずっとBabelを使い続けるのか?](slide/34.md)
 	- [Contributing](slide/35.md)

--- a/md/all.md
+++ b/md/all.md
@@ -327,7 +327,7 @@ ES.nextの仕様に入るには2つ以上の実装が必要
 
 -------
 
-## Tranpiler is not Learning tools
+## Transpiler is not Learning tools
 
 ![slide](http://azu.github.io/slide/nodejs-es6/img/JavaScript_transformation.png)
 

--- a/slide/32.md
+++ b/slide/32.md
@@ -1,3 +1,3 @@
-## Tranpiler is not Learning tools
+## Transpiler is not Learning tools
 
 ![slide](http://azu.github.io/slide/nodejs-es6/img/JavaScript_transformation.png)


### PR DESCRIPTION
s/Tranpiler/Tran`s`piler/g という些細な修正ですが、一応送りますー。
